### PR TITLE
feat: use description to encourage appropriate merge/squash/rebase strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ on your repos to ensure your pull requests are semantic before you merge them.
 
 ## How it works
 
-Take this PR for example. None of the commit messages are semantic, nor is the PR title, so the status remains yellow:
+Scenario | Status | Status Check Message
+-------- | ------ | -------
+PR title is [semantic][conventional commit type] | 💚 | `ready to be squashed`
+any commit is semantic | 💚 | `ready to be merged or rebased`
+nothing is semantic | 💛 | `add a semantic commit or PR title`
 
+## Example Scenario
+
+Take this PR for example. None of the commit messages are semantic, nor is the PR title, so the status remains yellow:
 
 <img width="580" alt="screen shot 2018-07-14 at 6 22 58 pm" src="https://user-images.githubusercontent.com/2289/42729630-11370698-8793-11e8-922c-db2308e0e98e.png">
 
@@ -19,7 +26,7 @@ Take this PR for example. None of the commit messages are semantic, nor is the P
 ---
 
 Edit the PR title by adding a semantic prefix like `fix: ` or `feat: ` or any other
-[conventional commit type](https://github.com/commitizen/conventional-commit-types/blob/master/index.json). Now use `Squash and Merge` to squash the branch onto master and write a standardized commit message while doing so:
+[conventional commit type]. Now use `Squash and Merge` to squash the branch onto master and write a standardized commit message while doing so:
 
 ---
 
@@ -35,3 +42,5 @@ Edit the PR title by adding a semantic prefix like `fix: ` or `feat: ` or any ot
 ## License
 
 [Apache 2.0](LICENSE)
+
+[conventional commit type]: https://github.com/commitizen/conventional-commit-types/blob/master/index.json

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -14,13 +14,22 @@ async function commitsAreSemantic (context) {
 
 async function handlePullRequestChange (context) {
   const {title, head} = context.payload.pull_request
-  const isSemantic = isSemanticMessage(title) || await commitsAreSemantic(context)
+  const hasSemanticTitle = isSemanticMessage(title)
+  const hasSemanticCommits = await commitsAreSemantic(context)
+  const isSemantic = hasSemanticTitle || hasSemanticCommits
   const state = isSemantic ? 'success' : 'pending'
+
+  function getDescription () {
+    if (hasSemanticTitle) return 'ready to be squashed'
+    if (hasSemanticCommits) return 'ready to be merged or rebased'
+    return 'add a semantic commit or PR title'
+  }
+
   const status = {
     sha: head.sha,
     state,
     target_url: 'https://github.com/probot/semantic-pull-requests',
-    description: isSemantic ? 'good to go' : 'add semantic commit or PR title',
+    description: getDescription(),
     context: 'Semantic Pull Request'
   }
   const result = await context.github.repos.createStatus(context.repo(status))


### PR DESCRIPTION
This PR updates the status check description to be more helpful:

- If the PR title is semantic, encourage squashing.
- If the title is not semantic but the commits are, encourage merging or rebasing.