### PR TITLE
fix: implement exception free getConfig

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -8,6 +8,22 @@ const DEFAULT_OPTS = {
   commitsOnly: false
 }
 
+const CONFIG_FILE = 'semantic.yml';
+
+/**
+ * @param  {Context} context A Probot context
+ * @param  {{titleOnly: boolean; commitsOnly: boolean}} defaultConfig
+ * @returns {{titleOnly: boolean; commitsOnly: boolean}}
+ * @async
+ */
+async function getConfigOrDefault(context, defaultConfig) {
+  try {
+    return await getConfig(context, CONFIG_FILE, defaultConfig);
+  } catch (_) {
+    return defaultConfig;
+  }
+}
+
 async function commitsAreSemantic (context, allCommits = false) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
@@ -17,9 +33,10 @@ async function commitsAreSemantic (context, allCommits = false) {
     .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message))
 }
 
+
 async function handlePullRequestChange (context, config) {
   const { title, head } = context.payload.pull_request
-  const { titleOnly, commitsOnly } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
+  const { titleOnly, commitsOnly } = await getConfigOrDefault(context, DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title)
   const hasSemanticCommits = await commitsAreSemantic(context, commitsOnly)
 

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -8,19 +8,19 @@ const DEFAULT_OPTS = {
   commitsOnly: false
 }
 
-const CONFIG_FILE = 'semantic.yml';
+const CONFIG_FILE = 'semantic.yml'
 
 /**
- * @param  {Context} context A Probot context
+ * @param  {import('probot').Context} context A Probot context
  * @param  {{titleOnly: boolean; commitsOnly: boolean}} defaultConfig
  * @returns {{titleOnly: boolean; commitsOnly: boolean}}
  * @async
  */
-async function getConfigOrDefault(context, defaultConfig) {
+async function getConfigOrDefault (context, defaultConfig) {
   try {
-    return await getConfig(context, CONFIG_FILE, defaultConfig);
+    return await getConfig(context, CONFIG_FILE, defaultConfig)
   } catch (_) {
-    return defaultConfig;
+    return defaultConfig
   }
 }
 
@@ -32,7 +32,6 @@ async function commitsAreSemantic (context, allCommits = false) {
   return commits.data
     .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message))
 }
-
 
 async function handlePullRequestChange (context, config) {
   const { title, head } = context.payload.pull_request

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -10,12 +10,6 @@ const DEFAULT_OPTS = {
 
 const CONFIG_FILE = 'semantic.yml'
 
-/**
- * @param  {import('probot').Context} context A Probot context
- * @param  {{titleOnly: boolean; commitsOnly: boolean}} defaultConfig
- * @returns {{titleOnly: boolean; commitsOnly: boolean}}
- * @async
- */
 async function getConfigOrDefault (context, defaultConfig) {
   try {
     return await getConfig(context, CONFIG_FILE, defaultConfig)


### PR DESCRIPTION
This PR introduces a `getConfigOrDefault` function that will handle all exception thrown by `getConfig` which only handles cases where API responds with 404. 

https://github.com/probot/semantic-pull-requests/issues/38