### PR TITLE
fix!: set status to `failure` instead of `pending`

### DIFF
--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -10,11 +10,11 @@ describe('handlePullRequestChange', () => {
     expect(typeof handlePullRequestChange).toBe('function')
   })
 
-  test('sets `pending` status if PR has no semantic commits and no semantic title', async () => {
+  test('sets `failure` status if PR has no semantic commits and no semantic title', async () => {
     const context = buildContext()
     context.payload.pull_request.title = 'do a thing'
     const expectedBody = {
-      state: 'pending',
+      state: 'failure',
       target_url: 'https://github.com/probot/semantic-pull-requests',
       description: 'add a semantic commit or PR title',
       context: 'Semantic Pull Request'
@@ -60,11 +60,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has semantic title with invalid scope', async () => {
+    test('sets `failure` status if PR has semantic title with invalid scope', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'fix(scope3): do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'add a semantic PR title',
         context: 'Semantic Pull Request'
@@ -87,11 +87,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has semantic commit with invalid scope', async () => {
+    test('sets `failure` status if PR has semantic commit with invalid scope', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'fix(scope3): do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'make sure every commit is semantic',
         context: 'Semantic Pull Request'
@@ -145,11 +145,11 @@ describe('handlePullRequestChange', () => {
   })
 
   describe('when `commitsOnly` is set to `true` in config', () => {
-    test('sets `pending` status if PR has no semantic commits', async () => {
+    test('sets `failure` status if PR has no semantic commits', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'make sure every commit is semantic',
         context: 'Semantic Pull Request'
@@ -167,11 +167,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has no semantic commits but has a semantic title', async () => {
+    test('sets `failure` status if PR has no semantic commits but has a semantic title', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'fix: do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'make sure every commit is semantic',
         context: 'Semantic Pull Request'
@@ -189,11 +189,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if one or commits are not well formed', async () => {
+    test('sets `failure` status if one or commits are not well formed', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'make sure every commit is semantic',
         context: 'Semantic Pull Request'
@@ -235,11 +235,11 @@ describe('handlePullRequestChange', () => {
   })
 
   describe('when `titleOnly` is set to `true` in config', () => {
-    test('sets `pending` status if PR has no semantic PR title', async () => {
+    test('sets `failure` status if PR has no semantic PR title', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'add a semantic PR title',
         context: 'Semantic Pull Request'
@@ -257,11 +257,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has no semantic PR title but has semantic commits', async () => {
+    test('sets `failure` status if PR has no semantic PR title but has semantic commits', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'add a semantic PR title',
         context: 'Semantic Pull Request'
@@ -303,11 +303,11 @@ describe('handlePullRequestChange', () => {
   })
 
   describe('when `titleAndCommits` is set to `true` in config', () => {
-    test('sets `pending` status if PR has no semantic PR title', async () => {
+    test('sets `failure` status if PR has no semantic PR title', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'add a semantic commit AND PR title',
         context: 'Semantic Pull Request'
@@ -325,11 +325,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has no semantic PR title but has semantic commits', async () => {
+    test('sets `failure` status if PR has no semantic PR title but has semantic commits', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'add a semantic commit AND PR title',
         context: 'Semantic Pull Request'
@@ -347,11 +347,11 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has no semantic PR title and has no semantic commits', async () => {
+    test('sets `failure` status if PR has no semantic PR title and has no semantic commits', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'do a thing'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         description: 'add a semantic commit AND PR title',
         context: 'Semantic Pull Request'
@@ -397,11 +397,11 @@ describe('handlePullRequestChange', () => {
       ['commitsOnly', 'add a semantic commit'],
       ['titleAndCommits', 'add a semantic commit AND PR title']
     ])('when no commits are semantic and `%s` is set to `true` in config', (configOption, description) => {
-      test(('sets `pending` status with description: ' + description), async () => {
+      test(('sets `failure` status with description: ' + description), async () => {
         const context = buildContext()
         context.payload.pull_request.title = 'fix: bananas'
         const expectedBody = {
-          state: 'pending',
+          state: 'failure',
           target_url: 'https://github.com/probot/semantic-pull-requests',
           description: description,
           context: 'Semantic Pull Request'
@@ -509,11 +509,11 @@ describe('handlePullRequestChange', () => {
   })
 
   describe('when `allowMergeCommits` is set to `false` AND `commitsOnly` is set to `true` in config', () => {
-    test('sets `pending` status if PR has Merge commit', async () => {
+    test('sets `failure` status if PR has Merge commit', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'fix: bananas'
       const expectedBody = {
-        state: 'pending',
+        state: 'failure',
         description: 'make sure every commit is semantic',
         target_url: 'https://github.com/probot/semantic-pull-requests',
         context: 'Semantic Pull Request'

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -48,7 +48,7 @@ async function handlePullRequestChange (context) {
     isSemantic = hasSemanticTitle || hasSemanticCommits
   }
 
-  const state = isSemantic ? 'success' : 'pending'
+  const state = isSemantic ? 'success' : 'failure'
 
   function getDescription () {
     if (isSemantic && titleAndCommits) return 'ready to be merged, squashed or rebased'

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -8,7 +8,7 @@ module.exports = function isSemanticMessage (message, validScopes, validTypes, a
   const { error, value: commits } = validate(message, true)
 
   if (error) {
-    console.error(error)
+    if (process.env.NODE_ENV !== 'test') console.error(error)
     return false
   }
 


### PR DESCRIPTION
This PR changes the app to report a `failure` status instead of `pending` for pull requests that are not yet semantic.

I originally chose to set the `pending` status as a way of keeping the PR from turning  ❌ RED ❌ to avoid causing unnecessary panic:

![Screen Shot 2019-11-25 at 6 21 50 PM](https://user-images.githubusercontent.com/2289/69594215-7cc27180-0fb0-11ea-8c7f-16a88d093316.png)

☝️ However this choice has caused some confusion. When people see the pending status, they tend to think the check is still running/incomplete.

cc @JustinBeckwith @michaelsbradleyjr @gr2m 

Resolves https://github.com/zeke/semantic-pull-requests/issues/76