### PR TITLE
feat: allow revert commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ types:
 allowMergeCommits: true
 ```
 
+```yml
+# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowRevertCommits: true
+```
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -537,6 +537,68 @@ describe('handlePullRequestChange', () => {
     })
   })
 
+  describe('when `allowRevertCommits` is set to `true` AND `commitsOnly`is set to `true` too in config', () => {
+    test('sets `success` status if PR has Merge commit', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'fix: bananas'
+      const expectedBody = {
+        state: 'success',
+        description: 'ready to be merged or rebased',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        context: 'Semantic Pull Request'
+      }
+
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, [
+          ...semanticCommits(),
+          { commit: { message: 'Revert "feat: ride unicorns"' } }
+        ])
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse(`
+          commitsOnly: true
+          scopes:
+            - scope1
+            - scope2
+          allowRevertCommits: true
+          `))
+
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
+  })
+
+  describe('when `allowRevertCommits` is set to `false` AND `commitsOnly` is set to `true` in config', () => {
+    test('sets `failure` status if PR has Merge commit', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'fix: bananas'
+      const expectedBody = {
+        state: 'failure',
+        description: 'make sure every commit is semantic',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        context: 'Semantic Pull Request'
+      }
+
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, [
+          { commit: { message: 'Revert "feat: ride unicorns"' } }
+        ])
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse(`
+          commitsOnly: true
+          allowRevertCommits: false
+          `))
+
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
+  })
+
   test('sets `success` status and `ready to be merged or squashed` description if PR has semantic commits but no semantic title', async () => {
     const context = buildContext()
     context.payload.pull_request.title = 'bananas'

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -10,16 +10,17 @@ const DEFAULT_OPTS = {
   anyCommit: false,
   scopes: null,
   types: null,
-  allowMergeCommits: false
+  allowMergeCommits: false,
+  allowRevertCommits: false
 }
 
-async function commitsAreSemantic (context, scopes, types, allCommits = false, allowMergeCommits) {
+async function commitsAreSemantic (context, scopes, types, allCommits = false, allowMergeCommits, allowRevertCommits) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
 
   return commits.data
-    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, types, allowMergeCommits))
+    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, types, allowMergeCommits, allowRevertCommits))
 }
 
 async function handlePullRequestChange (context) {
@@ -31,10 +32,11 @@ async function handlePullRequestChange (context) {
     anyCommit,
     scopes,
     types,
-    allowMergeCommits
+    allowMergeCommits,
+    allowRevertCommits
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title, scopes, types)
-  const hasSemanticCommits = await commitsAreSemantic(context, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits)
+  const hasSemanticCommits = await commitsAreSemantic(context, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits, allowRevertCommits)
 
   let isSemantic
 

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,9 +1,12 @@
 const commitTypes = Object.keys(require('conventional-commit-types').types)
 const { validate } = require('parse-commit-message')
 
-module.exports = function isSemanticMessage (message, validScopes, validTypes, allowMergeCommits) {
+module.exports = function isSemanticMessage (message, validScopes, validTypes, allowMergeCommits, allowRevertCommits) {
   const isMergeCommit = message && message.startsWith('Merge')
   if (allowMergeCommits && isMergeCommit) return true
+
+  const isRevertCommit = message && message.startsWith('Revert')
+  if (allowRevertCommits && isRevertCommit) return true
 
   const { error, value: commits } = validate(message, true)
 


### PR DESCRIPTION
Added support for revert commits, because there are cases when our engineers need to rollback a commit without resetting the branch state (revert over reset).