### PR TITLE
fix: disallow squashing of unsemantic single-commit PRs

### DIFF
--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -599,72 +599,96 @@ describe('handlePullRequestChange', () => {
     })
   })
 
-  test('sets `success` status and `ready to be merged or squashed` description if PR has semantic commits but no semantic title', async () => {
-    const context = buildContext()
-    context.payload.pull_request.title = 'bananas'
-    const expectedBody = {
-      state: 'success',
-      description: 'ready to be merged or rebased',
-      target_url: 'https://github.com/probot/semantic-pull-requests',
-      context: 'Semantic Pull Request'
-    }
+  describe('vanilla setup (no config)', () => {
+    test('sets `success` status and `ready to be merged or squashed` description if PR has semantic commits but no semantic title', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'bananas'
+      const expectedBody = {
+        state: 'success',
+        description: 'ready to be merged or rebased',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        context: 'Semantic Pull Request'
+      }
 
-    const mock = nock('https://api.github.com')
-      .get('/repos/sally/project-x/pulls/123/commits')
-      .reply(200, semanticCommits())
-      .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
-      .reply(200)
-      .get('/repos/sally/project-x/contents/.github/semantic.yml')
-      .reply(200, getConfigResponse())
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, semanticCommits())
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse())
 
-    await handlePullRequestChange(context)
-    expect(mock.isDone()).toBe(true)
-  })
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
 
-  test('encourages squashing when title is semantic but commits are not', async () => {
-    const context = buildContext()
-    context.payload.pull_request.title = 'fix: bananas'
-    const expectedBody = {
-      state: 'success',
-      description: 'ready to be squashed',
-      target_url: 'https://github.com/probot/semantic-pull-requests',
-      context: 'Semantic Pull Request'
-    }
+    test('sets `failure` status and `PR has only one commit and it\'s not semantic` description if PR has has only one un-semantic commit', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'fix: I am a semantic PR title but there is only commit unsemantic commit that will not be squashed!'
+      const expectedBody = {
+        state: 'failure',
+        description: 'PR has only one commit and it\'s not semantic; add another commit before squashing',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        context: 'Semantic Pull Request'
+      }
 
-    // since the title is semantic, no GET request for commits is needed
-    const mock = nock('https://api.github.com')
-      .get('/repos/sally/project-x/pulls/123/commits')
-      .reply(200, unsemanticCommits())
-      .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
-      .reply(200)
-      .get('/repos/sally/project-x/contents/.github/semantic.yml')
-      .reply(200, getConfigResponse())
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, unsemanticCommits().slice(0, 1))
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse())
 
-    await handlePullRequestChange(context)
-    expect(mock.isDone()).toBe(true)
-  })
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
 
-  test('allows `build:` as a prefix', async () => {
-    const context = buildContext()
-    context.payload.pull_request.title = 'build: publish to npm'
-    const expectedBody = {
-      state: 'success',
-      description: 'ready to be squashed',
-      target_url: 'https://github.com/probot/semantic-pull-requests',
-      context: 'Semantic Pull Request'
-    }
+    test('encourages squashing when title is semantic but commits are not', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'fix: bananas'
+      const expectedBody = {
+        state: 'success',
+        description: 'ready to be squashed',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        context: 'Semantic Pull Request'
+      }
 
-    // since the title is semantic, no GET request for commits is needed
-    const mock = nock('https://api.github.com')
-      .get('/repos/sally/project-x/pulls/123/commits')
-      .reply(200, unsemanticCommits())
-      .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
-      .reply(200)
-      .get('/repos/sally/project-x/contents/.github/semantic.yml')
-      .reply(200, getConfigResponse())
+      // since the title is semantic, no GET request for commits is needed
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, unsemanticCommits())
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse())
 
-    await handlePullRequestChange(context)
-    expect(mock.isDone()).toBe(true)
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
+
+    test('allows `build:` as a prefix', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'build: publish to npm'
+      const expectedBody = {
+        state: 'success',
+        description: 'ready to be squashed',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        context: 'Semantic Pull Request'
+      }
+
+      // since the title is semantic, no GET request for commits is needed
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, unsemanticCommits())
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse())
+
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
   })
 })
 

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -12,7 +12,7 @@ describe('isSemanticMessage', () => {
   test('returns false on bad input', () => {
     expect(isSemanticMessage('')).toBe(false)
     expect(isSemanticMessage(null)).toBe(false)
-    expect(isSemanticMessage('non-semantic commit message')).toBe(false)
+    expect(isSemanticMessage('unsemantic commit message')).toBe(false)
   })
 
   test('should check message scope', () => {

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -14,17 +14,22 @@ const DEFAULT_OPTS = {
   allowRevertCommits: false
 }
 
-async function commitsAreSemantic (context, scopes, types, allCommits = false, allowMergeCommits, allowRevertCommits) {
+async function getCommits (context) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
-
   return commits.data
+}
+
+async function commitsAreSemantic (commits, scopes, types, allCommits = false, allowMergeCommits, allowRevertCommits) {
+  return commits
     .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, types, allowMergeCommits, allowRevertCommits))
 }
 
 async function handlePullRequestChange (context) {
   const { title, head } = context.payload.pull_request
+  const userConfig = await getConfig(context, 'semantic.yml', {})
+  const isVanillaConfig = Object.keys(userConfig).length === 0
   const {
     titleOnly,
     commitsOnly,
@@ -34,9 +39,10 @@ async function handlePullRequestChange (context) {
     types,
     allowMergeCommits,
     allowRevertCommits
-  } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
+  } = Object.assign({}, DEFAULT_OPTS, userConfig)
   const hasSemanticTitle = isSemanticMessage(title, scopes, types)
-  const hasSemanticCommits = await commitsAreSemantic(context, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits, allowRevertCommits)
+  const commits = await getCommits(context)
+  const hasSemanticCommits = await commitsAreSemantic(commits, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits, allowRevertCommits)
 
   let isSemantic
 
@@ -46,6 +52,10 @@ async function handlePullRequestChange (context) {
     isSemantic = hasSemanticCommits
   } else if (titleAndCommits) {
     isSemantic = hasSemanticTitle && hasSemanticCommits
+  } else if (isVanillaConfig && commits.length === 1) {
+    // Watch out for cases where there's only commit and it's not semantic.
+    // GitHub won't squash PRs that have only one commit.
+    isSemantic = hasSemanticCommits
   } else {
     isSemantic = hasSemanticTitle || hasSemanticCommits
   }
@@ -53,6 +63,7 @@ async function handlePullRequestChange (context) {
   const state = isSemantic ? 'success' : 'failure'
 
   function getDescription () {
+    if (!isSemantic && isVanillaConfig && commits.length === 1) return 'PR has only one commit and it\'s not semantic; add another commit before squashing'
     if (isSemantic && titleAndCommits) return 'ready to be merged, squashed or rebased'
     if (!isSemantic && titleAndCommits) return 'add a semantic commit AND PR title'
     if (hasSemanticTitle && !commitsOnly) return 'ready to be squashed'


### PR DESCRIPTION
There's a subtle GitHub "bug" where squashed pull requests that only have one commit don't end up creating a squash commit.

This PR will make the GitHub app return a failing check in the following scenario:

- This GitHub app is installed with no custom configuration (no `./github/semantic.yml` file)
- A new pull request is opened with only one commit
- That one commit is not semantic

Resolves https://github.com/zeke/semantic-pull-requests/issues/17

cc @rachmari @jmarlena @lucascosti @martin389