### PR TITLE
fix: Fail on single unsemantic non-merge commit

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -43,6 +43,7 @@ async function handlePullRequestChange (context) {
   const hasSemanticTitle = isSemanticMessage(title, scopes, types)
   const commits = await getCommits(context)
   const hasSemanticCommits = await commitsAreSemantic(commits, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits, allowRevertCommits)
+  const nonMergeCommits = commits.filter(element => !element.commit.message.startsWith('Merge'))
 
   let isSemantic
 
@@ -52,7 +53,7 @@ async function handlePullRequestChange (context) {
     isSemantic = hasSemanticCommits
   } else if (titleAndCommits) {
     isSemantic = hasSemanticTitle && hasSemanticCommits
-  } else if (isVanillaConfig && commits.length === 1) {
+  } else if (isVanillaConfig && nonMergeCommits.length === 1) {
     // Watch out for cases where there's only commit and it's not semantic.
     // GitHub won't squash PRs that have only one commit.
     isSemantic = hasSemanticCommits
@@ -63,7 +64,7 @@ async function handlePullRequestChange (context) {
   const state = isSemantic ? 'success' : 'failure'
 
   function getDescription () {
-    if (!isSemantic && isVanillaConfig && commits.length === 1) return 'PR has only one commit and it\'s not semantic; add another commit before squashing'
+    if (!isSemantic && isVanillaConfig && nonMergeCommits.length === 1) return 'PR has only one non-merge commit and it\'s not semantic; add another commit before squashing'
     if (isSemantic && titleAndCommits) return 'ready to be merged, squashed or rebased'
     if (!isSemantic && titleAndCommits) return 'add a semantic commit AND PR title'
     if (hasSemanticTitle && !commitsOnly) return 'ready to be squashed'


### PR DESCRIPTION
This fixes yet another caveat of GitHub's behaviour mentioned in #17: GitHub does not count merge commits in this case.

A PR with one regular unsemantic commit and only merge commits afterwards will be allowed by the bot, even though GitHub will replace the squashed title with the one non-merge commit title.