### PR TITLE
feat: added regex support for scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ anyCommit: true
 ```
 
 ```yml
-# You can define a list of valid scopes
+# You can define a list of valid scopes and use regular expressions for more dynamic scopes
 scopes:
   - scope1
-  - scope2
+  - /^TASK-(\\d)+$/
   ...
 ```
 

--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -35,7 +35,7 @@ describe('handlePullRequestChange', () => {
   describe('custom scopes', () => {
     test('sets `success` status if PR has semantic title with available scope', async () => {
       const context = buildContext()
-      context.payload.pull_request.title = 'fix(scope1): bananas'
+      context.payload.pull_request.title = 'fix(TASK-1234): bananas'
       const expectedBody = {
         state: 'success',
         description: 'ready to be squashed',
@@ -53,7 +53,7 @@ describe('handlePullRequestChange', () => {
           titleOnly: true
           scopes:
             - scope1
-            - scope2
+            - /^TASK-(\\d)+$/
           `))
 
       await handlePullRequestChange(context)

--- a/__tests__/is-scope-valid.js
+++ b/__tests__/is-scope-valid.js
@@ -1,0 +1,95 @@
+const isScopeValid = require("../lib/is-scope-valid");
+
+describe("isScopeValid", () => {
+  test("allows parenthetical scope following the type", () => {
+    expect(isScopeValid([{ scope: "subsystem" }], ["subsystem"])).toBe(true);
+  });
+
+  test("allows exact match on strings", () => {
+    expect(isScopeValid([{ scope: "validScope" }], ["validScope"])).toBe(true);
+    expect(isScopeValid([{ scope: "" }], [])).toBe(true);
+    expect(isScopeValid([{ scope: null }], [])).toBe(true);
+    expect(isScopeValid([{ scope: undefined }], [])).toBe(true);
+    expect(isScopeValid([{ scope: "allowAllScopes" }], undefined)).toBe(true);
+    expect(isScopeValid([{ scope: "allowAllScopes" }], null)).toBe(true);
+  });
+
+  test("rejects not match and substring matches", () => {
+    expect(isScopeValid([{ scope: "bad" }], ["validScope"])).toBe(false);
+    expect(isScopeValid([{ scope: "invalidScope" }], ["validScope"])).toBe(
+      false
+    );
+  });
+
+  test("Validates multiple scope combinations", () => {
+    expect(isScopeValid([{ scope: "" }], [])).toBe(true);
+
+    expect(
+      isScopeValid(
+        [{ scope: "validScope,anotherValidScope" }],
+        ["validScope", "anotherValidScope"]
+      )
+    ).toBe(true);
+
+    expect(
+      isScopeValid(
+        [{ scope: "validScope, spaceAndAnotherValidScope" }],
+        ["validScope", "spaceAndAnotherValidScope"]
+      )
+    ).toBe(true);
+
+    expect(
+      isScopeValid([{ scope: "validScope, inValidScope" }], ["validScope"])
+    ).toBe(false);
+  });
+
+  test("Validates regex scopes", () => {
+    expect(
+      isScopeValid([{ scope: "partialvalidScope" }], ["/validScope/"])
+    ).toBe(true);
+
+    expect(isScopeValid([{ scope: "partialvalidScope" }], ["validScope"])).toBe(
+      false
+    );
+
+    expect(isScopeValid([{ scope: "validScope-1" }], ["validScope-\\d/"])).toBe(
+      true
+    );
+
+    expect(
+      isScopeValid(
+        [{ scope: "validScope-1,validScope-2" }],
+        ["/validScope-\\d/"]
+      )
+    ).toBe(true);
+
+    expect(
+      isScopeValid([{ scope: "validScope-10" }], ["/validScope-\\d+/"])
+    ).toBe(true);
+
+    expect(
+      isScopeValid([{ scope: "validScope-10" }], ["/^validScope-\\d$/"])
+    ).toBe(false);
+
+    expect(
+      isScopeValid(
+        [{ scope: "TASK-1,TASK-0001,TASK-1234" }],
+        ["/^TASK-(\\d)+$/"]
+      )
+    ).toBe(true);
+
+    expect(
+      isScopeValid(
+        [{ scope: "TASK-1,TASK-0001,validScope" }],
+        ["/^TASK-(\\d)+$/", "validScope"]
+      )
+    ).toBe(true);
+
+    expect(
+      isScopeValid(
+        [{ scope: "TASK-1,TASK-0001,invalidScope" }],
+        ["/^TASK-(\\d)+$/", "validScope"]
+      )
+    ).toBe(false);
+  });
+});

--- a/lib/is-scope-valid.js
+++ b/lib/is-scope-valid.js
@@ -1,0 +1,21 @@
+module.exports = function isScopeValid([{ scope: scopes }], validScopes) {
+  const isRegex = /(^\/|\/$)/g;
+  const validRegex = (valid, scope) =>
+    new RegExp(valid.replace(isRegex, "")).test(scope);
+  const validExact = (valid, scope) => valid === scope;
+
+  return (
+    !validScopes ||
+    !scopes ||
+    scopes
+      .split(",")
+      .map((scope) => scope.trim())
+      .every((scope) =>
+        validScopes.some((valid) =>
+          valid.match(isRegex)
+            ? validRegex(valid, scope)
+            : validExact(valid, scope)
+        )
+      )
+  );
+};

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,4 +1,5 @@
 const commitTypes = Object.keys(require("conventional-commit-types").types);
+const isScopeValid = require("./is-scope-valid");
 const { validate } = require("parse-commit-message");
 
 module.exports = function isSemanticMessage(
@@ -21,14 +22,9 @@ module.exports = function isSemanticMessage(
     return false;
   }
 
-  const [result] = commits;
-  const { scope: scopes, type } = result.header;
-  const isScopeValid =
-    !validScopes ||
-    !scopes ||
-    scopes
-      .split(",")
-      .map((scope) => scope.trim())
-      .every((scope) => validScopes.includes(scope));
-  return (validTypes || commitTypes).includes(type) && isScopeValid;
+  const { type } = result.header;
+  return (
+    (validTypes || commitTypes).includes(type) &&
+    isScopeValid(commits, validScopes)
+  );
 };

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -17,6 +17,8 @@ module.exports = function isSemanticMessage (message, validScopes, validTypes, a
 
   const [result] = commits
   const { scope, type } = result.header
-  const isScopeValid = !validScopes || !scope || validScopes.includes(scope)
+  const isScopeValid = !validScopes || !scope || validScopes.some(function(valid) { 
+    return new RegExp(valid.replace(/(^\/|\/$)/g, "")).test(scope) 
+  })
   return (validTypes || commitTypes).includes(type) && isScopeValid
 }


### PR DESCRIPTION
RegEx support for scopes. This enables support for any project management system to enforce naming conventions in their PRs. 

```
# You can define a list of valid scopes
scopes:
  - scope1
  - /^TASK-(\\d)+$/
  ...
```