### PR TITLE
fix: scope validation

### DIFF
--- a/__tests__/is-scope-valid.js
+++ b/__tests__/is-scope-valid.js
@@ -1,95 +1,117 @@
 const isScopeValid = require("../lib/is-scope-valid");
 
+const createMockData = (header) => [{ header }];
+
 describe("isScopeValid", () => {
   test("allows parenthetical scope following the type", () => {
-    expect(isScopeValid([{ scope: "subsystem" }], ["subsystem"])).toBe(true);
+    expect(
+      isScopeValid(createMockData({ scope: "subsystem" }), ["subsystem"])
+    ).toBe(true);
   });
 
   test("allows exact match on strings", () => {
-    expect(isScopeValid([{ scope: "validScope" }], ["validScope"])).toBe(true);
-    expect(isScopeValid([{ scope: "" }], [])).toBe(true);
-    expect(isScopeValid([{ scope: null }], [])).toBe(true);
-    expect(isScopeValid([{ scope: undefined }], [])).toBe(true);
-    expect(isScopeValid([{ scope: "allowAllScopes" }], undefined)).toBe(true);
-    expect(isScopeValid([{ scope: "allowAllScopes" }], null)).toBe(true);
+    expect(
+      isScopeValid(createMockData({ scope: "validScope" }), ["validScope"])
+    ).toBe(true);
+    expect(isScopeValid(createMockData({ scope: "" }), [])).toBe(true);
+    expect(isScopeValid(createMockData({ scope: null }), [])).toBe(true);
+    expect(isScopeValid(createMockData({ scope: undefined }), [])).toBe(true);
+    expect(
+      isScopeValid(createMockData({ scope: "allowAllScopes" }), undefined)
+    ).toBe(true);
+    expect(
+      isScopeValid(createMockData({ scope: "allowAllScopes" }), null)
+    ).toBe(true);
   });
 
   test("rejects not match and substring matches", () => {
-    expect(isScopeValid([{ scope: "bad" }], ["validScope"])).toBe(false);
-    expect(isScopeValid([{ scope: "invalidScope" }], ["validScope"])).toBe(
+    expect(isScopeValid(createMockData({ scope: "bad" }), ["validScope"])).toBe(
       false
     );
+    expect(
+      isScopeValid(createMockData({ scope: "invalidScope" }), ["validScope"])
+    ).toBe(false);
   });
 
   test("Validates multiple scope combinations", () => {
-    expect(isScopeValid([{ scope: "" }], [])).toBe(true);
+    expect(isScopeValid(createMockData({ scope: "" }), [])).toBe(true);
 
     expect(
-      isScopeValid(
-        [{ scope: "validScope,anotherValidScope" }],
-        ["validScope", "anotherValidScope"]
-      )
+      isScopeValid(createMockData({ scope: "validScope,anotherValidScope" }), [
+        "validScope",
+        "anotherValidScope",
+      ])
     ).toBe(true);
 
     expect(
       isScopeValid(
-        [{ scope: "validScope, spaceAndAnotherValidScope" }],
+        createMockData({ scope: "validScope, spaceAndAnotherValidScope" }),
         ["validScope", "spaceAndAnotherValidScope"]
       )
     ).toBe(true);
 
     expect(
-      isScopeValid([{ scope: "validScope, inValidScope" }], ["validScope"])
+      isScopeValid(createMockData({ scope: "validScope, inValidScope" }), [
+        "validScope",
+      ])
     ).toBe(false);
   });
 
   test("Validates regex scopes", () => {
     expect(
-      isScopeValid([{ scope: "partialvalidScope" }], ["/validScope/"])
-    ).toBe(true);
-
-    expect(isScopeValid([{ scope: "partialvalidScope" }], ["validScope"])).toBe(
-      false
-    );
-
-    expect(isScopeValid([{ scope: "validScope-1" }], ["validScope-\\d/"])).toBe(
-      true
-    );
-
-    expect(
-      isScopeValid(
-        [{ scope: "validScope-1,validScope-2" }],
-        ["/validScope-\\d/"]
-      )
+      isScopeValid(createMockData({ scope: "partialvalidScope" }), [
+        "/validScope/",
+      ])
     ).toBe(true);
 
     expect(
-      isScopeValid([{ scope: "validScope-10" }], ["/validScope-\\d+/"])
-    ).toBe(true);
-
-    expect(
-      isScopeValid([{ scope: "validScope-10" }], ["/^validScope-\\d$/"])
+      isScopeValid(createMockData({ scope: "partialvalidScope" }), [
+        "validScope",
+      ])
     ).toBe(false);
 
     expect(
-      isScopeValid(
-        [{ scope: "TASK-1,TASK-0001,TASK-1234" }],
-        ["/^TASK-(\\d)+$/"]
-      )
+      isScopeValid(createMockData({ scope: "validScope-1" }), [
+        "validScope-\\d/",
+      ])
     ).toBe(true);
 
     expect(
-      isScopeValid(
-        [{ scope: "TASK-1,TASK-0001,validScope" }],
-        ["/^TASK-(\\d)+$/", "validScope"]
-      )
+      isScopeValid(createMockData({ scope: "validScope-1,validScope-2" }), [
+        "/validScope-\\d/",
+      ])
     ).toBe(true);
 
     expect(
-      isScopeValid(
-        [{ scope: "TASK-1,TASK-0001,invalidScope" }],
-        ["/^TASK-(\\d)+$/", "validScope"]
-      )
+      isScopeValid(createMockData({ scope: "validScope-10" }), [
+        "/validScope-\\d+/",
+      ])
+    ).toBe(true);
+
+    expect(
+      isScopeValid(createMockData({ scope: "validScope-10" }), [
+        "/^validScope-\\d$/",
+      ])
+    ).toBe(false);
+
+    expect(
+      isScopeValid(createMockData({ scope: "TASK-1,TASK-0001,TASK-1234" }), [
+        "/^TASK-(\\d)+$/",
+      ])
+    ).toBe(true);
+
+    expect(
+      isScopeValid(createMockData({ scope: "TASK-1,TASK-0001,validScope" }), [
+        "/^TASK-(\\d)+$/",
+        "validScope",
+      ])
+    ).toBe(true);
+
+    expect(
+      isScopeValid(createMockData({ scope: "TASK-1,TASK-0001,invalidScope" }), [
+        "/^TASK-(\\d)+$/",
+        "validScope",
+      ])
     ).toBe(false);
   });
 });

--- a/__tests__/is-scope-valid.js
+++ b/__tests__/is-scope-valid.js
@@ -1,117 +1,117 @@
-const isScopeValid = require("../lib/is-scope-valid");
+const isScopeValid = require('../lib/is-scope-valid')
 
-const createMockData = (header) => [{ header }];
+const createMockData = (header) => [{ header }]
 
-describe("isScopeValid", () => {
-  test("allows parenthetical scope following the type", () => {
+describe('isScopeValid', () => {
+  test('allows parenthetical scope following the type', () => {
     expect(
-      isScopeValid(createMockData({ scope: "subsystem" }), ["subsystem"])
-    ).toBe(true);
-  });
+      isScopeValid(createMockData({ scope: 'subsystem' }), ['subsystem'])
+    ).toBe(true)
+  })
 
-  test("allows exact match on strings", () => {
+  test('allows exact match on strings', () => {
     expect(
-      isScopeValid(createMockData({ scope: "validScope" }), ["validScope"])
-    ).toBe(true);
-    expect(isScopeValid(createMockData({ scope: "" }), [])).toBe(true);
-    expect(isScopeValid(createMockData({ scope: null }), [])).toBe(true);
-    expect(isScopeValid(createMockData({ scope: undefined }), [])).toBe(true);
+      isScopeValid(createMockData({ scope: 'validScope' }), ['validScope'])
+    ).toBe(true)
+    expect(isScopeValid(createMockData({ scope: '' }), [])).toBe(true)
+    expect(isScopeValid(createMockData({ scope: null }), [])).toBe(true)
+    expect(isScopeValid(createMockData({ scope: undefined }), [])).toBe(true)
     expect(
-      isScopeValid(createMockData({ scope: "allowAllScopes" }), undefined)
-    ).toBe(true);
+      isScopeValid(createMockData({ scope: 'allowAllScopes' }), undefined)
+    ).toBe(true)
     expect(
-      isScopeValid(createMockData({ scope: "allowAllScopes" }), null)
-    ).toBe(true);
-  });
+      isScopeValid(createMockData({ scope: 'allowAllScopes' }), null)
+    ).toBe(true)
+  })
 
-  test("rejects not match and substring matches", () => {
-    expect(isScopeValid(createMockData({ scope: "bad" }), ["validScope"])).toBe(
+  test('rejects not match and substring matches', () => {
+    expect(isScopeValid(createMockData({ scope: 'bad' }), ['validScope'])).toBe(
       false
-    );
+    )
     expect(
-      isScopeValid(createMockData({ scope: "invalidScope" }), ["validScope"])
-    ).toBe(false);
-  });
+      isScopeValid(createMockData({ scope: 'invalidScope' }), ['validScope'])
+    ).toBe(false)
+  })
 
-  test("Validates multiple scope combinations", () => {
-    expect(isScopeValid(createMockData({ scope: "" }), [])).toBe(true);
+  test('Validates multiple scope combinations', () => {
+    expect(isScopeValid(createMockData({ scope: '' }), [])).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "validScope,anotherValidScope" }), [
-        "validScope",
-        "anotherValidScope",
+      isScopeValid(createMockData({ scope: 'validScope,anotherValidScope' }), [
+        'validScope',
+        'anotherValidScope'
       ])
-    ).toBe(true);
+    ).toBe(true)
 
     expect(
       isScopeValid(
-        createMockData({ scope: "validScope, spaceAndAnotherValidScope" }),
-        ["validScope", "spaceAndAnotherValidScope"]
+        createMockData({ scope: 'validScope, spaceAndAnotherValidScope' }),
+        ['validScope', 'spaceAndAnotherValidScope']
       )
-    ).toBe(true);
+    ).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "validScope, inValidScope" }), [
-        "validScope",
+      isScopeValid(createMockData({ scope: 'validScope, inValidScope' }), [
+        'validScope'
       ])
-    ).toBe(false);
-  });
+    ).toBe(false)
+  })
 
-  test("Validates regex scopes", () => {
+  test('Validates regex scopes', () => {
     expect(
-      isScopeValid(createMockData({ scope: "partialvalidScope" }), [
-        "/validScope/",
+      isScopeValid(createMockData({ scope: 'partialvalidScope' }), [
+        '/validScope/'
       ])
-    ).toBe(true);
-
-    expect(
-      isScopeValid(createMockData({ scope: "partialvalidScope" }), [
-        "validScope",
-      ])
-    ).toBe(false);
+    ).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "validScope-1" }), [
-        "validScope-\\d/",
+      isScopeValid(createMockData({ scope: 'partialvalidScope' }), [
+        'validScope'
       ])
-    ).toBe(true);
+    ).toBe(false)
 
     expect(
-      isScopeValid(createMockData({ scope: "validScope-1,validScope-2" }), [
-        "/validScope-\\d/",
+      isScopeValid(createMockData({ scope: 'validScope-1' }), [
+        'validScope-\\d/'
       ])
-    ).toBe(true);
+    ).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "validScope-10" }), [
-        "/validScope-\\d+/",
+      isScopeValid(createMockData({ scope: 'validScope-1,validScope-2' }), [
+        '/validScope-\\d/'
       ])
-    ).toBe(true);
+    ).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "validScope-10" }), [
-        "/^validScope-\\d$/",
+      isScopeValid(createMockData({ scope: 'validScope-10' }), [
+        '/validScope-\\d+/'
       ])
-    ).toBe(false);
+    ).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "TASK-1,TASK-0001,TASK-1234" }), [
-        "/^TASK-(\\d)+$/",
+      isScopeValid(createMockData({ scope: 'validScope-10' }), [
+        '/^validScope-\\d$/'
       ])
-    ).toBe(true);
+    ).toBe(false)
 
     expect(
-      isScopeValid(createMockData({ scope: "TASK-1,TASK-0001,validScope" }), [
-        "/^TASK-(\\d)+$/",
-        "validScope",
+      isScopeValid(createMockData({ scope: 'TASK-1,TASK-0001,TASK-1234' }), [
+        '/^TASK-(\\d)+$/'
       ])
-    ).toBe(true);
+    ).toBe(true)
 
     expect(
-      isScopeValid(createMockData({ scope: "TASK-1,TASK-0001,invalidScope" }), [
-        "/^TASK-(\\d)+$/",
-        "validScope",
+      isScopeValid(createMockData({ scope: 'TASK-1,TASK-0001,validScope' }), [
+        '/^TASK-(\\d)+$/',
+        'validScope'
       ])
-    ).toBe(false);
-  });
-});
+    ).toBe(true)
+
+    expect(
+      isScopeValid(createMockData({ scope: 'TASK-1,TASK-0001,invalidScope' }), [
+        '/^TASK-(\\d)+$/',
+        'validScope'
+      ])
+    ).toBe(false)
+  })
+})

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -1,140 +1,140 @@
-const isSemanticMessage = require("../lib/is-semantic-message");
+const isSemanticMessage = require('../lib/is-semantic-message')
 
-describe("isSemanticMessage", () => {
-  test("returns true when messages are semantic", () => {
-    expect(isSemanticMessage("fix: something")).toBe(true);
-  });
+describe('isSemanticMessage', () => {
+  test('returns true when messages are semantic', () => {
+    expect(isSemanticMessage('fix: something')).toBe(true)
+  })
 
-  test("allows parenthetical scope following the type", () => {
-    expect(isSemanticMessage("fix(subsystem): something")).toBe(true);
-  });
+  test('allows parenthetical scope following the type', () => {
+    expect(isSemanticMessage('fix(subsystem): something')).toBe(true)
+  })
 
-  test("returns false on bad input", () => {
-    expect(isSemanticMessage("")).toBe(false);
-    expect(isSemanticMessage(null)).toBe(false);
-    expect(isSemanticMessage("unsemantic commit message")).toBe(false);
-  });
+  test('returns false on bad input', () => {
+    expect(isSemanticMessage('')).toBe(false)
+    expect(isSemanticMessage(null)).toBe(false)
+    expect(isSemanticMessage('unsemantic commit message')).toBe(false)
+  })
 
-  test("should check message scope", () => {
+  test('should check message scope', () => {
     expect(
-      isSemanticMessage("fix(validScope): something", ["validScope"])
-    ).toBe(true);
+      isSemanticMessage('fix(validScope): something', ['validScope'])
+    ).toBe(true)
     expect(
-      isSemanticMessage("fix(invalidScope): something", ["validScope"])
-    ).toBe(false);
+      isSemanticMessage('fix(invalidScope): something', ['validScope'])
+    ).toBe(false)
     expect(
-      isSemanticMessage("fix(validScope,anotherValidScope): something", [
-        "validScope",
-        "anotherValidScope",
+      isSemanticMessage('fix(validScope,anotherValidScope): something', [
+        'validScope',
+        'anotherValidScope'
       ])
-    ).toBe(true);
+    ).toBe(true)
     expect(
       isSemanticMessage(
-        "fix(validScope, spaceAndAnotherValidScope): something",
-        ["validScope", "spaceAndAnotherValidScope"]
+        'fix(validScope, spaceAndAnotherValidScope): something',
+        ['validScope', 'spaceAndAnotherValidScope']
       )
-    ).toBe(true);
+    ).toBe(true)
     expect(
-      isSemanticMessage("fix(validScope,inValidScope): something", [
-        "validScope",
+      isSemanticMessage('fix(validScope,inValidScope): something', [
+        'validScope'
       ])
-    ).toBe(false);
-    expect(isSemanticMessage("fix(): something", ["validScope"])).toBe(false);
-  });
+    ).toBe(false)
+    expect(isSemanticMessage('fix(): something', ['validScope'])).toBe(false)
+  })
 
-  test("allows merge commits", () => {
+  test('allows merge commits', () => {
     expect(
       isSemanticMessage("Merge branch 'master' into patch-1", null, null, true)
-    ).toBe(true);
+    ).toBe(true)
 
     expect(
       isSemanticMessage(
-        "Merge refs/heads/master into angry-burritos/US-335",
-        ["scope1"],
+        'Merge refs/heads/master into angry-burritos/US-335',
+        ['scope1'],
         null,
         true
       )
-    ).toBe(true);
-  });
-});
+    ).toBe(true)
+  })
+})
 
-describe("isSemanticMessage - Handling validTypes", () => {
-  test("return true for all default types when validTypes is provided", () => {
-    expect(isSemanticMessage("feat: something")).toBe(true);
-    expect(isSemanticMessage("fix: something")).toBe(true);
-    expect(isSemanticMessage("docs: something")).toBe(true);
-    expect(isSemanticMessage("style: something")).toBe(true);
-    expect(isSemanticMessage("refactor: something")).toBe(true);
-    expect(isSemanticMessage("perf: something")).toBe(true);
-    expect(isSemanticMessage("test: something")).toBe(true);
-    expect(isSemanticMessage("build: something")).toBe(true);
-    expect(isSemanticMessage("ci: something")).toBe(true);
-    expect(isSemanticMessage("chore: something")).toBe(true);
-    expect(isSemanticMessage("revert: something")).toBe(true);
-  });
+describe('isSemanticMessage - Handling validTypes', () => {
+  test('return true for all default types when validTypes is provided', () => {
+    expect(isSemanticMessage('feat: something')).toBe(true)
+    expect(isSemanticMessage('fix: something')).toBe(true)
+    expect(isSemanticMessage('docs: something')).toBe(true)
+    expect(isSemanticMessage('style: something')).toBe(true)
+    expect(isSemanticMessage('refactor: something')).toBe(true)
+    expect(isSemanticMessage('perf: something')).toBe(true)
+    expect(isSemanticMessage('test: something')).toBe(true)
+    expect(isSemanticMessage('build: something')).toBe(true)
+    expect(isSemanticMessage('ci: something')).toBe(true)
+    expect(isSemanticMessage('chore: something')).toBe(true)
+    expect(isSemanticMessage('revert: something')).toBe(true)
+  })
 
-  test("return false for none default types when validTypes is provided", () => {
-    expect(isSemanticMessage("alternative: something")).toBe(false);
-  });
+  test('return false for none default types when validTypes is provided', () => {
+    expect(isSemanticMessage('alternative: something')).toBe(false)
+  })
 
-  test("return true for types included in supplied validTypes", () => {
-    const customConventionalCommitType = ["alternative", "improvement"];
+  test('return true for types included in supplied validTypes', () => {
+    const customConventionalCommitType = ['alternative', 'improvement']
 
     expect(
       isSemanticMessage(
-        "alternative: something",
+        'alternative: something',
         null,
         customConventionalCommitType
       )
-    ).toBe(true);
+    ).toBe(true)
     expect(
       isSemanticMessage(
-        "improvement: something",
+        'improvement: something',
         null,
         customConventionalCommitType
       )
-    ).toBe(true);
-  });
+    ).toBe(true)
+  })
 
-  test("return false for types NOT included in supplied validTypes", () => {
-    const customConventionalCommitType = ["alternative", "improvement"];
+  test('return false for types NOT included in supplied validTypes', () => {
+    const customConventionalCommitType = ['alternative', 'improvement']
 
     expect(
-      isSemanticMessage("feat: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('feat: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("fix: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('fix: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("docs: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('docs: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("style: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('style: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
       isSemanticMessage(
-        "refactor: something",
+        'refactor: something',
         null,
         customConventionalCommitType
       )
-    ).toBe(false);
+    ).toBe(false)
     expect(
-      isSemanticMessage("perf: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('perf: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("test: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('test: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("build: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('build: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("ci: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('ci: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("chore: something", null, customConventionalCommitType)
-    ).toBe(false);
+      isSemanticMessage('chore: something', null, customConventionalCommitType)
+    ).toBe(false)
     expect(
-      isSemanticMessage("revert: something", null, customConventionalCommitType)
-    ).toBe(false);
-  });
-});
+      isSemanticMessage('revert: something', null, customConventionalCommitType)
+    ).toBe(false)
+  })
+})

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -1,81 +1,140 @@
-const isSemanticMessage = require('../lib/is-semantic-message')
+const isSemanticMessage = require("../lib/is-semantic-message");
 
-describe('isSemanticMessage', () => {
-  test('returns true when messages are semantic', () => {
-    expect(isSemanticMessage('fix: something')).toBe(true)
-  })
+describe("isSemanticMessage", () => {
+  test("returns true when messages are semantic", () => {
+    expect(isSemanticMessage("fix: something")).toBe(true);
+  });
 
-  test('allows parenthetical scope following the type', () => {
-    expect(isSemanticMessage('fix(subsystem): something')).toBe(true)
-  })
+  test("allows parenthetical scope following the type", () => {
+    expect(isSemanticMessage("fix(subsystem): something")).toBe(true);
+  });
 
-  test('returns false on bad input', () => {
-    expect(isSemanticMessage('')).toBe(false)
-    expect(isSemanticMessage(null)).toBe(false)
-    expect(isSemanticMessage('unsemantic commit message')).toBe(false)
-  })
+  test("returns false on bad input", () => {
+    expect(isSemanticMessage("")).toBe(false);
+    expect(isSemanticMessage(null)).toBe(false);
+    expect(isSemanticMessage("unsemantic commit message")).toBe(false);
+  });
 
-  test('should check message scope', () => {
-    expect(isSemanticMessage('fix(validScope): something', ['validScope'])).toBe(true)
-    expect(isSemanticMessage('fix(invalidScope): something', ['validScope'])).toBe(false)
-    expect(isSemanticMessage('fix(validScope,anotherValidScope): something', ['validScope', 'anotherValidScope'])).toBe(true)
-    expect(isSemanticMessage('fix(validScope, spaceAndAnotherValidScope): something', ['validScope', 'spaceAndAnotherValidScope'])).toBe(true)
-    expect(isSemanticMessage('fix(validScope,inValidScope): something', ['validScope'])).toBe(false)
-    expect(isSemanticMessage('fix(): something', ['validScope'])).toBe(false)
-  })
+  test("should check message scope", () => {
+    expect(
+      isSemanticMessage("fix(validScope): something", ["validScope"])
+    ).toBe(true);
+    expect(
+      isSemanticMessage("fix(invalidScope): something", ["validScope"])
+    ).toBe(false);
+    expect(
+      isSemanticMessage("fix(validScope,anotherValidScope): something", [
+        "validScope",
+        "anotherValidScope",
+      ])
+    ).toBe(true);
+    expect(
+      isSemanticMessage(
+        "fix(validScope, spaceAndAnotherValidScope): something",
+        ["validScope", "spaceAndAnotherValidScope"]
+      )
+    ).toBe(true);
+    expect(
+      isSemanticMessage("fix(validScope,inValidScope): something", [
+        "validScope",
+      ])
+    ).toBe(false);
+    expect(isSemanticMessage("fix(): something", ["validScope"])).toBe(false);
+  });
 
-  test('allows merge commits', () => {
-    expect(isSemanticMessage('Merge branch \'master\' into patch-1', null, null, true)).toBe(true)
+  test("allows merge commits", () => {
+    expect(
+      isSemanticMessage("Merge branch 'master' into patch-1", null, null, true)
+    ).toBe(true);
 
-    expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['scope1'], null, true)).toBe(true)
-  })
-})
+    expect(
+      isSemanticMessage(
+        "Merge refs/heads/master into angry-burritos/US-335",
+        ["scope1"],
+        null,
+        true
+      )
+    ).toBe(true);
+  });
+});
 
-describe('isSemanticMessage - Handling validTypes', () => {
-  test('return true for all default types when validTypes is provided', () => {
-    expect(isSemanticMessage('feat: something')).toBe(true)
-    expect(isSemanticMessage('fix: something')).toBe(true)
-    expect(isSemanticMessage('docs: something')).toBe(true)
-    expect(isSemanticMessage('style: something')).toBe(true)
-    expect(isSemanticMessage('refactor: something')).toBe(true)
-    expect(isSemanticMessage('perf: something')).toBe(true)
-    expect(isSemanticMessage('test: something')).toBe(true)
-    expect(isSemanticMessage('build: something')).toBe(true)
-    expect(isSemanticMessage('ci: something')).toBe(true)
-    expect(isSemanticMessage('chore: something')).toBe(true)
-    expect(isSemanticMessage('revert: something')).toBe(true)
-  })
+describe("isSemanticMessage - Handling validTypes", () => {
+  test("return true for all default types when validTypes is provided", () => {
+    expect(isSemanticMessage("feat: something")).toBe(true);
+    expect(isSemanticMessage("fix: something")).toBe(true);
+    expect(isSemanticMessage("docs: something")).toBe(true);
+    expect(isSemanticMessage("style: something")).toBe(true);
+    expect(isSemanticMessage("refactor: something")).toBe(true);
+    expect(isSemanticMessage("perf: something")).toBe(true);
+    expect(isSemanticMessage("test: something")).toBe(true);
+    expect(isSemanticMessage("build: something")).toBe(true);
+    expect(isSemanticMessage("ci: something")).toBe(true);
+    expect(isSemanticMessage("chore: something")).toBe(true);
+    expect(isSemanticMessage("revert: something")).toBe(true);
+  });
 
-  test('return false for none default types when validTypes is provided', () => {
-    expect(isSemanticMessage('alternative: something')).toBe(false)
-  })
+  test("return false for none default types when validTypes is provided", () => {
+    expect(isSemanticMessage("alternative: something")).toBe(false);
+  });
 
-  test('return true for types included in supplied validTypes', () => {
-    const customConventionalCommitType = [
-      'alternative',
-      'improvement'
-    ]
+  test("return true for types included in supplied validTypes", () => {
+    const customConventionalCommitType = ["alternative", "improvement"];
 
-    expect(isSemanticMessage('alternative: something', null, customConventionalCommitType)).toBe(true)
-    expect(isSemanticMessage('improvement: something', null, customConventionalCommitType)).toBe(true)
-  })
+    expect(
+      isSemanticMessage(
+        "alternative: something",
+        null,
+        customConventionalCommitType
+      )
+    ).toBe(true);
+    expect(
+      isSemanticMessage(
+        "improvement: something",
+        null,
+        customConventionalCommitType
+      )
+    ).toBe(true);
+  });
 
-  test('return false for types NOT included in supplied validTypes', () => {
-    const customConventionalCommitType = [
-      'alternative',
-      'improvement'
-    ]
+  test("return false for types NOT included in supplied validTypes", () => {
+    const customConventionalCommitType = ["alternative", "improvement"];
 
-    expect(isSemanticMessage('feat: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('fix: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('docs: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('style: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('refactor: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('perf: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('test: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('build: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('ci: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('chore: something', null, customConventionalCommitType)).toBe(false)
-    expect(isSemanticMessage('revert: something', null, customConventionalCommitType)).toBe(false)
-  })
-})
+    expect(
+      isSemanticMessage("feat: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("fix: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("docs: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("style: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage(
+        "refactor: something",
+        null,
+        customConventionalCommitType
+      )
+    ).toBe(false);
+    expect(
+      isSemanticMessage("perf: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("test: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("build: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("ci: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("chore: something", null, customConventionalCommitType)
+    ).toBe(false);
+    expect(
+      isSemanticMessage("revert: something", null, customConventionalCommitType)
+    ).toBe(false);
+  });
+});

--- a/lib/is-scope-valid.js
+++ b/lib/is-scope-valid.js
@@ -1,4 +1,11 @@
-module.exports = function isScopeValid([{ scope: scopes }], validScopes) {
+module.exports = function isScopeValid(
+  [
+    {
+      header: { scope: scopes },
+    },
+  ],
+  validScopes
+) {
   const isRegex = /(^\/|\/$)/g;
   const validRegex = (valid, scope) =>
     new RegExp(valid.replace(isRegex, "")).test(scope);
@@ -11,11 +18,12 @@ module.exports = function isScopeValid([{ scope: scopes }], validScopes) {
       .split(",")
       .map((scope) => scope.trim())
       .every((scope) =>
-        validScopes.some((valid) =>
-          valid.match(isRegex)
+        validScopes.some((valid) => {
+          console.log("scope:", valid, "test:", scope);
+          return valid.match(isRegex)
             ? validRegex(valid, scope)
-            : validExact(valid, scope)
-        )
+            : validExact(valid, scope);
+        })
       )
   );
 };

--- a/lib/is-scope-valid.js
+++ b/lib/is-scope-valid.js
@@ -1,29 +1,28 @@
-module.exports = function isScopeValid(
+module.exports = function isScopeValid (
   [
     {
-      header: { scope: scopes },
-    },
+      header: { scope: scopes }
+    }
   ],
   validScopes
 ) {
-  const isRegex = /(^\/|\/$)/g;
+  const isRegex = /(^\/|\/$)/g
   const validRegex = (valid, scope) =>
-    new RegExp(valid.replace(isRegex, "")).test(scope);
-  const validExact = (valid, scope) => valid === scope;
+    new RegExp(valid.replace(isRegex, '')).test(scope)
+  const validExact = (valid, scope) => valid === scope
 
   return (
     !validScopes ||
     !scopes ||
     scopes
-      .split(",")
+      .split(',')
       .map((scope) => scope.trim())
       .every((scope) =>
         validScopes.some((valid) => {
-          console.log("scope:", valid, "test:", scope);
           return valid.match(isRegex)
             ? validRegex(valid, scope)
-            : validExact(valid, scope);
+            : validExact(valid, scope)
         })
       )
-  );
-};
+  )
+}

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,30 +1,30 @@
-const commitTypes = Object.keys(require("conventional-commit-types").types);
-const isScopeValid = require("./is-scope-valid");
-const { validate } = require("parse-commit-message");
+const commitTypes = Object.keys(require('conventional-commit-types').types)
+const isScopeValid = require('./is-scope-valid')
+const { validate } = require('parse-commit-message')
 
-module.exports = function isSemanticMessage(
+module.exports = function isSemanticMessage (
   message,
   validScopes,
   validTypes,
   allowMergeCommits,
   allowRevertCommits
 ) {
-  const isMergeCommit = message && message.startsWith("Merge");
-  if (allowMergeCommits && isMergeCommit) return true;
+  const isMergeCommit = message && message.startsWith('Merge')
+  if (allowMergeCommits && isMergeCommit) return true
 
-  const isRevertCommit = message && message.startsWith("Revert");
-  if (allowRevertCommits && isRevertCommit) return true;
+  const isRevertCommit = message && message.startsWith('Revert')
+  if (allowRevertCommits && isRevertCommit) return true
 
-  const { error, value: commits } = validate(message, true);
+  const { error, value: commits } = validate(message, true)
 
   if (error) {
-    if (process.env.NODE_ENV !== "test") console.error(error);
-    return false;
+    if (process.env.NODE_ENV !== 'test') console.error(error)
+    return false
   }
 
-  const [result] = commits;
-  const { type } = result.header;
-  const validCommitType = (validTypes || commitTypes).includes(type);
-  const isValidScope = isScopeValid(commits, validScopes);
-  return validCommitType && isValidScope;
-};
+  const [result] = commits
+  const { type } = result.header
+  const validCommitType = (validTypes || commitTypes).includes(type)
+  const isValidScope = isScopeValid(commits, validScopes)
+  return validCommitType && isValidScope
+}

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -22,9 +22,9 @@ module.exports = function isSemanticMessage(
     return false;
   }
 
+  const [result] = commits;
   const { type } = result.header;
-  return (
-    (validTypes || commitTypes).includes(type) &&
-    isScopeValid(commits, validScopes)
-  );
+  const validCommitType = (validTypes || commitTypes).includes(type);
+  const isValidScope = isScopeValid(commits, validScopes);
+  return validCommitType && isValidScope;
 };


### PR DESCRIPTION
In #124 the test for scope validation was broken.
The code was testing the commit header data, but was given the whole commit when validating semantic message.

This should fix #125 