### PR TITLE
fix: run CI on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 
 name: ci
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Should prevent future outages like this one: https://github.com/zeke/semantic-pull-requests/issues/125