### PR TITLE
Fix use of semantic.yml

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -1,7 +1,6 @@
 module.exports = handlePullRequestChange
 
 const isSemanticMessage = require('./is-semantic-message')
-const getConfig = require('probot-config')
 
 const DEFAULT_OPTS = {
   titleOnly: false,
@@ -28,7 +27,7 @@ async function commitsAreSemantic (commits, scopes, types, allCommits = false, a
 
 async function handlePullRequestChange (context) {
   const { title, head } = context.payload.pull_request
-  const userConfig = await getConfig(context, 'semantic.yml', {})
+  const userConfig = await context.config('semantic.yml')
   const isVanillaConfig = Object.keys(userConfig).length === 0
   const {
     titleOnly,

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "conventional-commit-types": "^3.0.0",
     "parse-commit-message": "^4.0.0-canary.20",
-    "probot": "^7.5.3",
-    "probot-config": "^1.0.0"
+    "probot": "^7.5.3"
   },
   "devDependencies": {
     "@octokit/rest": "^15.9.4",


### PR DESCRIPTION
Resolves #141

Use the probot context object to acess the user-defined config instead of the deprecated `probot-config` package.