### PR TITLE
feat: add enabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ behaviors, you can add a `semantic.yml` file to your `.github` directory with
 the following optional settings:
 
 ```yml
+# Disable validation, and skip status check creation
+enabled: false
+```
+
+```yml
 # Always validate the PR title, and ignore the commits
 titleOnly: true
 ```

--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -32,6 +32,30 @@ describe('handlePullRequestChange', () => {
     expect(mock.isDone()).toBe(true)
   })
 
+  describe('when `enabled` is set to `false` in config', () => {
+    test('sets `success` status with a skipped message', async () => {
+      const context = buildContext()
+      context.payload.pull_request.title = 'do a thing'
+      const expectedBody = {
+        state: 'success',
+        target_url: 'https://github.com/probot/semantic-pull-requests',
+        description: 'skipped; check disabled in semantic.yml config',
+        context: 'Semantic Pull Request'
+      }
+
+      const mock = nock('https://api.github.com')
+        .get('/repos/sally/project-x/pulls/123/commits')
+        .reply(200, unsemanticCommits())
+        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
+        .reply(200)
+        .get('/repos/sally/project-x/contents/.github/semantic.yml')
+        .reply(200, getConfigResponse(`enabled: false`))
+
+      await handlePullRequestChange(context)
+      expect(mock.isDone()).toBe(true)
+    })
+  })
+
   describe('custom scopes', () => {
     test('sets `success` status if PR has semantic title with available scope', async () => {
       const context = buildContext()

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -4,6 +4,7 @@ const isSemanticMessage = require('./is-semantic-message')
 const getConfig = require('probot-config')
 
 const DEFAULT_OPTS = {
+  enabled: true,
   titleOnly: false,
   commitsOnly: false,
   titleAndCommits: false,
@@ -31,6 +32,7 @@ async function handlePullRequestChange (context) {
   const userConfig = await getConfig(context, 'semantic.yml', {})
   const isVanillaConfig = Object.keys(userConfig).length === 0
   const {
+    enabled,
     titleOnly,
     commitsOnly,
     titleAndCommits,
@@ -40,6 +42,7 @@ async function handlePullRequestChange (context) {
     allowMergeCommits,
     allowRevertCommits
   } = Object.assign({}, DEFAULT_OPTS, userConfig)
+
   const hasSemanticTitle = isSemanticMessage(title, scopes, types)
   const commits = await getCommits(context)
   const hasSemanticCommits = await commitsAreSemantic(commits, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits, allowRevertCommits)
@@ -47,7 +50,9 @@ async function handlePullRequestChange (context) {
 
   let isSemantic
 
-  if (titleOnly) {
+  if (!enabled) {
+    isSemantic = true
+  } else if (titleOnly) {
     isSemantic = hasSemanticTitle
   } else if (commitsOnly) {
     isSemantic = hasSemanticCommits
@@ -64,6 +69,7 @@ async function handlePullRequestChange (context) {
   const state = isSemantic ? 'success' : 'failure'
 
   function getDescription () {
+    if (!enabled) return 'skipped; check disabled in semantic.yml config'
     if (!isSemantic && isVanillaConfig && nonMergeCommits.length === 1) return 'PR has only one non-merge commit and it\'s not semantic; add another commit before squashing'
     if (isSemantic && titleAndCommits) return 'ready to be merged, squashed or rebased'
     if (!isSemantic && titleAndCommits) return 'add a semantic commit AND PR title'


### PR DESCRIPTION
Our organization allows engineers to create microservices using Spotify's Backstage developer portal. All of these services follow conventional commits. However, we have some repositories in our organization (Helm Charts) that use other release strategies.

We don't want to have to switch to manually adding a newly created service to this configuration every time someone creates a new microservice from Backstage. Instead, we'd rather "opt out" of this merge check on a per-repo basis.

This adds the `enabled` configuration option, which defaults to `true` to avoid breaking changes. This would allow organizations in our situation the ability to set `enabled: false` in `.github/semantic.yml` to disable this merge check.